### PR TITLE
reject fake host headers

### DIFF
--- a/ec_api/settings/base_lambda.py
+++ b/ec_api/settings/base_lambda.py
@@ -1,7 +1,7 @@
 from .base import *  # noqa
 import os
 
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = [os.environ.get("APP_DOMAIN")]
 DEBUG = os.environ.get("DEBUG", False)
 
 WHITENOISE_AUTOREFRESH = False


### PR DESCRIPTION
Currently leaflets allows anything in the host header. This makes the site vulnerable to a range of spoofing attacks. This PR tightens this setting up in line with (for example)

https://github.com/DemocracyClub/Website/blob/fd5b3e57fdef5caac46a7591344bd1ae3b7b3e5b/democracy_club/settings/aws_lambda.py#L17

The `APP_DOMAIN` env var is configured at
https://github.com/DemocracyClub/ec-api-proxy/blob/4d9d170b79d61ebfc4faee79d64b334f14fa1e1a/template.yaml#L117