### PR TITLE
Feat/basic auth lambda 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
       DJANGO_SETTINGS_MODULE: "<<parameters.dc-django-settings-module>>"
       SAM_CONFIG_FILE: samconfig.toml.d/ci-<<parameters.dc-environment>>.toml
       DC_ENVIRONMENT: <<parameters.dc-environment>>
-      SAM_PUBLIC_CONFIG_ENV: <<parameters.dc-environment>>-public-access
       SAM_LAMBDA_FUNCTION_CONFIG_ENV: <<parameters.dc-environment>>-cloudfront-lambda-functions
       DC_DEPLOY_NAME: <<parameters.dc-deploy-name>>
       POSTGRES_DATABASE_NAME: <<parameters.dc-deploy-name>>
@@ -106,7 +105,7 @@ jobs:
     - run: *install-pipenv
     - run: pip install aws-sam-cli
 
-    - run: printenv DC_DEPLOY_NAME DJANGO_SETTINGS_MODULE SAM_CONFIG_FILE DC_ENVIRONMENT SAM_PUBLIC_CONFIG_ENV
+    - run: printenv DC_DEPLOY_NAME DJANGO_SETTINGS_MODULE SAM_CONFIG_FILE DC_ENVIRONMENT
     - run: printenv SECRET_KEY | md5sum
     - run: printenv AWS_ACCESS_KEY_ID | md5sum
     - run: sudo apt update && sudo apt install postgresql-client
@@ -158,7 +157,7 @@ jobs:
         command: |
           pipenv run sam deploy ${DASH_DASH_DEBUG} \
             --config-file ~/repo/${SAM_CONFIG_FILE} \
-            --config-env $SAM_PUBLIC_CONFIG_ENV \
+            --config-env ${DC_ENVIRONMENT}-public-access \
             --template-file ~/repo/public-access-template.yaml \
             --parameter-overrides " \
                StackNameSuffix=<<parameters.dc-environment>> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
     environment:
       DJANGO_SETTINGS_MODULE: "<<parameters.dc-django-settings-module>>"
       SAM_CONFIG_FILE: samconfig.toml.d/ci-<<parameters.dc-environment>>.toml
-      SAM_LAMBDA_CONFIG_ENV: <<parameters.dc-environment>>
+      DC_ENVIRONMENT: <<parameters.dc-environment>>
       SAM_PUBLIC_CONFIG_ENV: <<parameters.dc-environment>>-public-access
       SAM_LAMBDA_FUNCTION_CONFIG_ENV: <<parameters.dc-environment>>-cloudfront-lambda-functions
       DC_DEPLOY_NAME: <<parameters.dc-deploy-name>>
@@ -106,7 +106,7 @@ jobs:
     - run: *install-pipenv
     - run: pip install aws-sam-cli
 
-    - run: printenv DC_DEPLOY_NAME DJANGO_SETTINGS_MODULE SAM_CONFIG_FILE SAM_LAMBDA_CONFIG_ENV SAM_PUBLIC_CONFIG_ENV
+    - run: printenv DC_DEPLOY_NAME DJANGO_SETTINGS_MODULE SAM_CONFIG_FILE DC_ENVIRONMENT SAM_PUBLIC_CONFIG_ENV
     - run: printenv SECRET_KEY | md5sum
     - run: printenv AWS_ACCESS_KEY_ID | md5sum
     - run: sudo apt update && sudo apt install postgresql-client
@@ -116,7 +116,7 @@ jobs:
         command: |
           pipenv run sam deploy ${DASH_DASH_DEBUG} \
             --config-file ~/repo/${SAM_CONFIG_FILE} \
-            --config-env $SAM_LAMBDA_CONFIG_ENV \
+            --config-env $DC_ENVIRONMENT \
             --template-file ~/repo/.aws-sam/build/template.yaml \
             --parameter-overrides " \
                AppDjangoSettingsModule=$DJANGO_SETTINGS_MODULE \
@@ -130,7 +130,6 @@ jobs:
                AppPostgresPassword='$POSTGRES_PASSWORD' \
                AppWidgetS3URL='$WIDGET_S3_URL' \
                AppDCAPIToken='$DC_API_TOKEN' \
-               AppSamLambdaConfigEnv='$SAM_LAMBDA_CONFIG_ENV' \
                AppDomain='$PUBLIC_FQDN' \
               "
         no_output_timeout: 30m

--- a/ec_api/settings/base.py
+++ b/ec_api/settings/base.py
@@ -199,7 +199,7 @@ def setup_sentry(environment=None):
         return
 
     if not environment:
-        environment = os.environ["SAM_LAMBDA_CONFIG_ENV"]
+        environment = os.environ["DC_ENVIRONMENT"]
     release = os.environ.get("GIT_HASH", "unknown")
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration

--- a/public-access-template.yaml
+++ b/public-access-template.yaml
@@ -61,7 +61,7 @@ Resources:
         Origins:
           - Id: Static
             DomainName:
-              Fn::ImportValue: !Sub "ECApiApp-${StackNameSuffix}:ECApiFqdn"
+              Fn::ImportValue: !Sub "ECApiApp-${StackNameSuffix}:ECApiFrontendFqdn"
             OriginPath: "/Prod"
             CustomOriginConfig:
               OriginProtocolPolicy: "https-only"
@@ -77,7 +77,7 @@ Resources:
 
           - Id: Dynamic
             DomainName:
-              Fn::ImportValue: !Sub "ECApiApp-${StackNameSuffix}:ECApiFqdn"
+              Fn::ImportValue: !Sub "ECApiApp-${StackNameSuffix}:ECApiFrontendFqdn"
             OriginPath: "/Prod"
             CustomOriginConfig:
               OriginProtocolPolicy: "https-only"

--- a/samconfig.toml.d/development.toml
+++ b/samconfig.toml.d/development.toml
@@ -26,7 +26,6 @@ parameter_overrides = """
   AppSecretKey=badf00d \
   AppIsBehindCloudFront=False \
   AppSentryDSN='' \
-  AppSamLambdaConfigEnv=dev \
   AppDomain='' \
   AppPostgresDatabaseName='' \
   AppPostgresPassword='' \

--- a/template.yaml
+++ b/template.yaml
@@ -63,9 +63,10 @@ Parameters:
     Description: "The URL to the widget JS"
     Type: String
 
-  AppSamLambdaConfigEnv:
-    Description: "The lambda config environment passed to the app used to init sentry."
-    Type: String
+  DCEnvironment:
+    Default: DC_ENVIRONMENT
+    Description: "The DC_ENVIRONMENT environment variable"
+    Type: AWS::SSM::Parameter::Value<String>
 
   AppDomain:
     Description: "The domain the app is on."
@@ -113,7 +114,7 @@ Resources:
           POSTGRES_DATABASE_NAME: !Ref AppPostgresDatabaseName
           POSTGRES_PASSWORD: !Ref AppPostgresPassword
           WIDGET_S3_URL: !Ref AppWidgetS3URL
-          SAM_LAMBDA_CONFIG_ENV: !Ref AppSamLambdaConfigEnv
+          DC_ENVIRONMENT: !Ref DCEnvironment
           APP_DOMAIN: !Ref AppDomain
           LOGGER_ARN: !Ref AppLoggerArn
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -155,7 +155,6 @@ Resources:
                 - token
               ReauthorizeEvery: 3600
 
-
   APIAuthFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -168,6 +167,7 @@ Resources:
           POSTGRES_DATABASE_NAME: !Ref AppPostgresDatabaseName
           POSTGRES_PASSWORD: !Ref AppPostgresPassword
       Runtime: python3.12
+
   V1VotingInformationFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -162,7 +162,6 @@ Resources:
       Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/ECApiLambdaExecutionRole"
       CodeUri: ./api_endpoints/api_auth
       Handler: handler.lambda_handler
-      AutoPublishAlias: live
       Environment:
         Variables:
           POSTGRES_HOST: !Ref AppPostgresHost
@@ -175,7 +174,6 @@ Resources:
       Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/ECApiLambdaExecutionRole"
       CodeUri: ./api_endpoints/v1_postcode_lookup/
       Handler: app.handler
-      AutoPublishAlias: live
       Runtime: python3.12
       MemorySize: 512
       Environment:

--- a/template.yaml
+++ b/template.yaml
@@ -126,6 +126,7 @@ Resources:
         HTTPRequestRoots:
           Type: Api
           Properties:
+            RestApiId: !Ref FrontendAPI
             Path: /
             Method: ANY
 
@@ -135,6 +136,17 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${ECApiFunction}
       RetentionInDays: !Ref AppLogRetentionDays
+
+  FrontendAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      AlwaysDeploy: True
+      StageName: Prod
+      Cors:
+        AllowMethods: "'GET'"
+        AllowOrigin: "'*'"
+        MaxAge: "'600'"
+
 
   ECAPI:
     Type: AWS::Serverless::Api
@@ -201,6 +213,13 @@ Outputs:
     Value: !Sub "${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"
     Export:
       Name: !Join [ ":", [ !Ref "AWS::StackName", "ECApiFqdn" ] ]
+
+  ECApiFrontendFqdn:
+    Description: "API Gateway endpoint FQDN for EC API function"
+    Value: !Sub "${FrontendAPI}.execute-api.${AWS::Region}.amazonaws.com"
+    Export:
+      Name: !Join [ ":", [ !Ref "AWS::StackName", "ECApiFrontendFqdn" ] ]
+
   ECStarletteApi:
     Description: "API Gateway endpoint FQDN for EC Starlette API function"
     Value: !Sub "${ECAPI}.execute-api.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
This is part 1 of a series of 2 PRs:

These PRs add a simple basic auth lambda in front of our dev and staging sites (See [Asana](https://app.asana.com/0/1204880927741389/1208294218492449/f)).

They also:
- rename the current env variable to DC_ENVIRONMENT for consistency
- remove the (mostly) unused SAM_PUBLIC_CONFIG_ENV variable
- Replaces the implicitly created API gateway in front of `ECApiFunction`  with an explicit named resource: `FrontendAPI`
 
### Deploy Process:

I need to deploy these changes in two stages,  because the `public-access-template` that deploys the CF distribution depends on the FQDN of the implicitly created API gateway (`ServerlessRestApi`) that is output by the app `template`:
https://github.com/DemocracyClub/ec-api-proxy/blob/eed3d8933ca234e70191cd9b1fd910bf241789df/template.yaml#L201-L204

And since the implicitly created API gateway is referenced by this output, I can't completely replace it until the output is changed. 

So, the first deploy updates the CF distribution to no longer reference the FQDN of the implicitly created API gateway, and the second deploy will delete the old output and remove the implicit API gateway in favor of `FrontendAPI`. 

In order to deploy twice, I've split this feature into two PRs to be merged on after the other. This is the first PR, and the second PR is here: https://github.com/DemocracyClub/ec-api-proxy/pull/233

### Testing

I've tested this deploy process by deploying in the same manner to staging. **Between the 1st and 2nd deploy, the frontend site will be broken**, but at no point during the deploy should the API stop functioning in any environment. 